### PR TITLE
fix: Unable to find handler code when library is consumed, Lambda times out before completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# replace this
+# cdk-library-aws-organization
+
+This CDK library is a WIP and not ready for production use.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   aws_iam as iam,
   CustomResource,
   aws_logs as logs,
+  Duration,
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -28,6 +29,7 @@ export class OrganizationOUProvider extends Construct {
       runtime: lambda.Runtime.PYTHON_3_9,
       code: lambda.Code.fromAsset(handlersPath + '/ou'),
       handler: 'index.on_event',
+      timeout: Duration.seconds(10),
     });
 
     let role: iam.IRole;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
   custom_resources,
   aws_lambda as lambda,
@@ -21,9 +22,11 @@ export class OrganizationOUProvider extends Construct {
   constructor(scope: Construct, id: string, props: OrganizationOUProviderProps) {
     super(scope, id);
 
+    const handlersPath = path.join(__dirname, '../handlers');
+
     const onEvent = new lambda.Function(this, 'handler', {
       runtime: lambda.Runtime.PYTHON_3_9,
-      code: lambda.Code.fromAsset('handlers/ou'),
+      code: lambda.Code.fromAsset(handlersPath + '/ou'),
       handler: 'index.on_event',
     });
 

--- a/test/__snapshots__/org.test.ts.snap
+++ b/test/__snapshots__/org.test.ts.snap
@@ -237,6 +237,7 @@ Object {
           ],
         },
         "Runtime": "python3.9",
+        "Timeout": 10,
       },
       "Type": "AWS::Lambda::Function",
     },


### PR DESCRIPTION
Fixes:
- Lambda function times out before completion for OU handler
- Handler code cant be found when consuming library