### PR TITLE
fix: Errors that didn't match duplicate org were ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # cdk-library-aws-organization
 
 This CDK library is a WIP and not ready for production use.
+
+## Testing the custom provider code with SAM CLI
+
+- Create a test project that utilizes this library
+- Create a test stack
+- Synthesize the test stack with `cdk synth --no-staging > template.yml`
+- Run `sam local invoke <function from stack> -e <event json file>`
+- There is some example events provided in the `events` folder, but you will need a real test org to run events against

--- a/events/create.json
+++ b/events/create.json
@@ -1,0 +1,14 @@
+{
+  "RequestType": "Create",
+  "ServiceToken": "arn:aws:lambda:us-east-1:123456789011:function:OrganizationStack-OrganizationOUProviderproviderfr-bhqHNYRVZfg2",
+  "ResponseURL": "foobar",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789011:stack/OrganizationStack/959824b0-67cf-11ec-a231-0e443d09d895",
+  "RequestId": "d98e54f4-c53f-423b-bf64-b8b4a7fe42f5",
+  "LogicalResourceId": "OrganizationOUouEDCB4747",
+  "ResourceType": "AWS::CloudFormation::CustomResource",
+  "ResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789011:function:OrganizationStack-OrganizationOUProviderproviderfr-bhqHNYRVZfg2",
+    "ParentId": "r-a1b2",
+    "Name": "TestOULib"
+  }
+}

--- a/events/update.json
+++ b/events/update.json
@@ -1,0 +1,20 @@
+{
+  "RequestType": "Update",
+  "ServiceToken": "arn:aws:lambda:us-east-1:123456789011:function:OrganizationStack-OrganizationOUProviderproviderfr-bhqHNYRVZfg2",
+  "ResponseURL": "foobar",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789011:stack/OrganizationStack/959824b0-67cf-11ec-a231-0e443d09d895",
+  "RequestId": "5b2a57ed-cc9c-4686-b4e7-5b522a5ba9d0",
+  "LogicalResourceId": "OrganizationOUouEDCB4747",
+  "PhysicalResourceId": "ou-g9g3-wl83rl0i",
+  "ResourceType": "AWS::CloudFormation::CustomResource",
+  "ResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789011:function:OrganizationStack-OrganizationOUProviderproviderfr-bhqHNYRVZfg2",
+    "ParentId": "r-a1b2",
+    "Name": "TestOULib2"
+  },
+  "OldResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789011:function:OrganizationStack-OrganizationOUProviderproviderfr-bhqHNYRVZfg2",
+    "ParentId": "r-a1b2",
+    "Name": "TestOULib"
+  }
+}

--- a/test/__snapshots__/org.test.ts.snap
+++ b/test/__snapshots__/org.test.ts.snap
@@ -227,7 +227,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "08922372b061ae31af841fa1c849d5a8ab96916bcb7a296543d9bad83655f4ca.zip",
+          "S3Key": "d10e8a28ce70340e268c02c9524cbb09651f0ce8c351e5ac96218f7d75c15b27.zip",
         },
         "Handler": "index.on_event",
         "Role": Object {


### PR DESCRIPTION
Previously any error code that wasn't a duplicate org didn't match the if statement so was eaten by the try/except and was never properly raised due to how botocore errors work